### PR TITLE
Fix ONNX benchmark instrumentation

### DIFF
--- a/onnx_benchmark/import_benchmarkscript.py
+++ b/onnx_benchmark/import_benchmarkscript.py
@@ -41,7 +41,6 @@ def profile_model(model_path, test_data, context):
     data_names = [graph_input for graph_input in sym.list_inputs()
                   if graph_input not in arg_params and graph_input not in aux_params]
 
-    inference_time = 0
     inference_time_list = []
     for data_idx, _ in enumerate(test_data):
         data_shapes = []
@@ -64,12 +63,10 @@ def profile_model(model_path, test_data, context):
         start = time.time()
         mod.forward(mx.io.DataBatch(data_forward))
         _ = mod.get_outputs()[0].asnumpy()
-        total_time = (time.time() - start) * 1000
-        inference_time += total_time
-        inference_time_list.append(total_time)
+        total_time_in_ms = (time.time() - start) * 1000
+        inference_time_list.append(total_time_in_ms)
 
-    avg_inference_time = inference_time / len(test_data)
-    return avg_inference_time, inference_time_list
+    return inference_time_list
 
 
 if __name__ == '__main__':
@@ -82,7 +79,8 @@ if __name__ == '__main__':
             model_path = os.path.join(model_dir, "model.onnx")
             test_data = get_model_input(model_dir)
 
-            avg_infer_time, infer_time_list = profile_model(model_path, test_data, ctx)
+            infer_time_list = profile_model(model_path, test_data, ctx)
+            avg_infer_time = np.average(infer_time_list)
             p50_infer_time = np.percentile(infer_time_list, 50)
             p90_infer_time = np.percentile(infer_time_list, 90)
             p99_infer_time = np.percentile(infer_time_list, 99)

--- a/onnx_benchmark/import_benchmarkscript.py
+++ b/onnx_benchmark/import_benchmarkscript.py
@@ -42,24 +42,20 @@ def profile_model(model_path, test_data, context):
                   if graph_input not in arg_params and graph_input not in aux_params]
 
     inference_time_list = []
-    for data_idx, _ in enumerate(test_data):
-        data_shapes = []
-        data_forward = []
-        for idx, input_name in enumerate(data_names):
-            val = test_data[idx + data_idx]
-            data_shapes.append((input_name, val.shape))
-            data_forward.append(mx.nd.array(val))
+    data_shapes = [(data_names[0], test_data[0].shape)]
 
-        # create a module
-        mod = mx.mod.Module(symbol=sym, data_names=data_names, context=ctx, label_names=None)
-        mod.bind(for_training=False, data_shapes=data_shapes, label_shapes=None)
+    # create a module
+    mod = mx.mod.Module(symbol=sym, data_names=data_names, context=ctx, label_names=None)
+    mod.bind(for_training=False, data_shapes=data_shapes, label_shapes=None)
 
-        # initializing parameters for calculating result of each individual node
-        if arg_params is None and aux_params is None:
-            mod.init_params()
-        else:
-            mod.set_params(arg_params=arg_params, aux_params=aux_params)
+     # initializing parameters for calculating result of each individual node
+    if arg_params is None and aux_params is None:
+        mod.init_params()
+    else:
+        mod.set_params(arg_params=arg_params, aux_params=aux_params)
 
+    for val in test_data:
+        data_forward = [mx.nd.array(val)]
         start = time.time()
         mod.forward(mx.io.DataBatch(data_forward))
         _ = mod.get_outputs()[0].asnumpy()

--- a/onnx_benchmark/import_benchmarkscript.py
+++ b/onnx_benchmark/import_benchmarkscript.py
@@ -37,6 +37,7 @@ def profile_model(model_path, test_data, context):
                   if graph_input not in arg_params and graph_input not in aux_params]
 
     inference_time = 0
+    inference_time_list = []
     for data_idx, _ in enumerate(test_data):
         data_shapes = []
         data_forward = []
@@ -62,9 +63,10 @@ def profile_model(model_path, test_data, context):
         # total_time = "{:.9f}".format(total_time)
         # log_data.update({test_data_name: total_time})
         inference_time += total_time
+        inference_time_list.append(total_time)
 
     avg_inference_time = inference_time / len(test_data)
-    return avg_inference_time
+    return avg_inference_time, inference_time_list
 
 
 if __name__ == '__main__':
@@ -77,6 +79,12 @@ if __name__ == '__main__':
             model_path = os.path.join(model_dir, "model.onnx")
             test_data = get_model_input(model_dir)
 
-            avg_infer_time = profile_model(model_path, test_data, ctx)
+            avg_infer_time, infer_time_list = profile_model(model_path, test_data, ctx)
+            p50_infer_time = np.percentile(infer_time_list, 50)
+            p90_infer_time = np.percentile(infer_time_list, 90)
+            p99_infer_time = np.percentile(infer_time_list, 99)
 
             print('Average_inference_time_{}_{}: {:.9f}'.format(directory, ctx, avg_infer_time))
+            print('P50_inference_time_{}_{}: {:.9f}'.format(directory, ctx, p50_infer_time))
+            print('P90_inference_time_{}_{}: {:.9f}'.format(directory, ctx, p90_infer_time))
+            print('P99_inference_time_{}_{}: {:.9f}'.format(directory, ctx, p99_infer_time))

--- a/onnx_benchmark/import_benchmarkscript.py
+++ b/onnx_benchmark/import_benchmarkscript.py
@@ -65,8 +65,6 @@ def profile_model(model_path, test_data, context):
         mod.forward(mx.io.DataBatch(data_forward))
         _ = mod.get_outputs()[0].asnumpy()
         total_time = (time.time() - start) * 1000
-        # total_time = "{:.9f}".format(total_time)
-        # log_data.update({test_data_name: total_time})
         inference_time += total_time
         inference_time_list.append(total_time)
 

--- a/onnx_benchmark/import_benchmarkscript.py
+++ b/onnx_benchmark/import_benchmarkscript.py
@@ -4,6 +4,7 @@ import glob
 import time
 import numpy as np
 
+
 def get_model_input(model_dir):
     import onnx
     from onnx import numpy_helper
@@ -26,7 +27,8 @@ def get_model_input(model_dir):
 
     return model_inputs
 
-def profile_model(model_path, test_data, context):   
+
+def profile_model(model_path, test_data, context):
     import mxnet as mx
 
     sym, arg_params, aux_params = mx.contrib.onnx.import_model(model_path)
@@ -37,8 +39,11 @@ def profile_model(model_path, test_data, context):
     inference_time = 0
     for data_idx, _ in enumerate(test_data):
         data_shapes = []
+        data_forward = []
         for idx, input_name in enumerate(data_names):
-            data_shapes.append((input_name, test_data[idx+data_idx].shape))
+            val = test_data[idx + data_idx]
+            data_shapes.append((input_name, val.shape))
+            data_forward.append(mx.nd.array(val))
 
         # create a module
         mod = mx.mod.Module(symbol=sym, data_names=data_names, context=ctx, label_names=None)
@@ -50,33 +55,28 @@ def profile_model(model_path, test_data, context):
         else:
             mod.set_params(arg_params=arg_params, aux_params=aux_params)
 
-        data_forward = []
-        for idx, input_name in enumerate(data_names):
-            val = test_data[idx+data_idx]
-            data_forward.append(mx.nd.array(val))
-
         start = time.time()
         mod.forward(mx.io.DataBatch(data_forward))
-        total_time =  (time.time() - start)*1000
-        #total_time = "{:.9f}".format(total_time)
+        _ = mod.get_outputs()[0].asnumpy()
+        total_time = (time.time() - start) * 1000
+        # total_time = "{:.9f}".format(total_time)
         # log_data.update({test_data_name: total_time})
         inference_time += total_time
-    
-    avg_inference_time = inference_time/len(test_data)
+
+    avg_inference_time = inference_time / len(test_data)
     return avg_inference_time
 
+
 if __name__ == '__main__':
-       from sys import argv
-       ctx = str(argv[1])
-       for directory in os.listdir("./models"):
-           model_dir = os.path.join("./models", directory)
-           if os.path.isdir(model_dir):
-               model_path = os.path.join(model_dir, "model.onnx")
-               test_data = get_model_input(model_dir)
+    from sys import argv
 
-               profile_data = profile_model(model_path, test_data, ctx)
+    ctx = str(argv[1])
+    for directory in os.listdir("./models"):
+        model_dir = os.path.join("./models", directory)
+        if os.path.isdir(model_dir):
+            model_path = os.path.join(model_dir, "model.onnx")
+            test_data = get_model_input(model_dir)
 
-               avg_inference_time = profile_model(model_path, test_data, ctx)
+            avg_infer_time = profile_model(model_path, test_data, ctx)
 
-               print('Average_inference_time_{}_{}: {:.9f}'.format(directory, ctx, avg_inference_time))
-
+            print('Average_inference_time_{}_{}: {:.9f}'.format(directory, ctx, avg_infer_time))

--- a/onnx_benchmark/import_benchmarkscript.py
+++ b/onnx_benchmark/import_benchmarkscript.py
@@ -25,6 +25,11 @@ def get_model_input(model_dir):
                 tensor.ParseFromString(f.read())
             model_inputs.append(numpy_helper.to_array(tensor))
 
+    input_shape = model_inputs[-1].shape
+    # generating 1000 data points for inference time test
+    for _ in range(1000 - len(model_inputs)):
+        model_inputs.append(np.random.randn(*input_shape))
+
     return model_inputs
 
 

--- a/onnx_benchmark/import_benchmarkscript.py
+++ b/onnx_benchmark/import_benchmarkscript.py
@@ -54,6 +54,8 @@ def profile_model(model_path, test_data, context):
     else:
         mod.set_params(arg_params=arg_params, aux_params=aux_params)
 
+    mx.nd.waitall()
+
     for val in test_data:
         data_forward = [mx.nd.array(val, ctx=ctx)]
         start = time.time()

--- a/reporting/utils/benchmarks.py
+++ b/reporting/utils/benchmarks.py
@@ -46,7 +46,8 @@ class Benchmarks(object):
         'Training NLP' : ['Framework', 'Framework Desc', 'Model', 'Benchmark Desc', 'Instance Type',
                           'Perplexity', 'Throughput', 'Time to Train', 'CPU Memory',
                           'GPU Memory Mean', 'GPU Memory Max', 'Uptime'],
-        'Model Import' : ['Framework', 'Model', 'Benchmark Desc', 'Instance Type', 'Latency']
+        'Model Import' : ['Framework', 'Model', 'Benchmark Desc', 'Instance Type', 'Latency',
+                          'P50 Latency', 'P90 Latency', 'P99 Latency']
     }
     HEADER_UNITS = {
         'Latency' : 'ms',


### PR DESCRIPTION
The ONNX benchmarking script was initiating a mod.forward call and not waiting for the results. Hence, the time taken for inference was observed to be in the range 0.2-0.3 ms. Adding a wait_to_read() call before measuring time taken. 

**Changes made:**
1. Get output as numpy to make a wait_to_read() call
2. Re-format code
3. There were 2 calls to profile_model() - changed this to use only one call
4. Optimized the loops in profile_model()
5. Calculating P50, P90, P99 apart form average

**Results:** (in ms)

Before:
```
CPU:
Average_inference_time_bvlc_alexnet_cpu: 0.146
Average_inference_time_bvlc_googlenet_cpu: 0.16
Average_inference_time_bvlc_reference_caffenet_cpu: 0.097
Average_inference_time_bvlc_reference_rcnn_ilsvrc13_cpu: 0.094
Average_inference_time_densenet121_cpu: 0.487
Average_inference_time_resnet50_cpu: 0.212
Average_inference_time_shufflenet_cpu: 0.182
Average_inference_time_squeezenet_cpu: 0.186
Average_inference_time_vgg19_cpu: 0.109

GPU:
Average_inference_time_bvlc_alexnet_gpu: 0.149
Average_inference_time_bvlc_googlenet_gpu: 0.291
Average_inference_time_bvlc_reference_caffenet_gpu: 0.173
Average_inference_time_bvlc_reference_rcnn_ilsvrc13_gpu: 0.132
Average_inference_time_densenet121_gpu: 0.457
Average_inference_time_resnet50_gpu: 0.287
Average_inference_time_shufflenet_gpu: 0.121
Average_inference_time_squeezenet_gpu: 0.114
Average_inference_time_vgg19_gpu: 0.319302082
```

After:
```
CPU: 
Average_inference_time_bvlc_alexnet_cpu: 422.245 
Average_inference_time_bvlc_googlenet_cpu: 132.785 
Average_inference_time_bvlc_reference_caffenet_cpu: 393.31 
Average_inference_time_bvlc_reference_rcnn_ilsvrc13_cpu: 410.365 
Average_inference_time_densenet121_cpu: 238.375 
Average_inference_time_resnet50_cpu: 284.59 
Average_inference_time_shufflenet_cpu: 59.065 
Average_inference_time_squeezenet_cpu: 28.255 
Average_inference_time_vgg19_cpu: 1312.475 

GPU: 
Average_inference_time_bvlc_alexnet_gpu: 367.475 
Average_inference_time_bvlc_googlenet_gpu: 528.63 
Average_inference_time_bvlc_reference_caffenet_gpu: 258.823 
Average_inference_time_bvlc_reference_rcnn_ilsvrc13_gpu: 383.478 
Average_inference_time_densenet121_gpu: 1547.645 
Average_inference_time_resnet50_gpu: 7673.85 
Average_inference_time_shufflenet_gpu: 2544.968 
Average_inference_time_squeezenet_gpu: 269.863 
Average_inference_time_vgg19_gpu: 2053.013
```

Thresholds will be changed accordingly