### PR TITLE
Upgrade pyyaml to version 4.2b1 or later for reporting requirements

### DIFF
--- a/reporting/requirements.txt
+++ b/reporting/requirements.txt
@@ -8,7 +8,7 @@ jmespath==0.9.3
 openpyxl==2.5.9
 python-dateutil==2.7.4
 pytz==2018.6
-PyYAML==3.13
+PyYAML>=4.2b1
 s3transfer==0.1.13
 six==1.11.0
 urllib3==1.24


### PR DESCRIPTION
Due to security vulnerability:

[CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342) high severity
Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.