### PR TITLE
Changing Resnet50 to Resnet18 for Scala

### DIFF
--- a/scala-mxnet/scala-bm/bin/get_resnet18_data.sh
+++ b/scala-mxnet/scala-bm/bin/get_resnet18_data.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+
+data_path=/tmp/resnet-18/
+
+image_path=$data_path/images/
+
+if [ ! -d "$data_path" ]; then
+  mkdir -p "$data_path"
+fi
+
+if [ ! -d "$image_path" ]; then
+  mkdir -p "$image_path"
+fi
+
+if [ ! -f "$data_path" ]; then
+  wget https://s3.us-east-2.amazonaws.com/scala-infer-models/resnet-18/resnet-18-symbol.json -P $data_path
+  wget https://s3.us-east-2.amazonaws.com/scala-infer-models/resnet-18/resnet-18-0000.params -P $data_path
+  wget https://s3.us-east-2.amazonaws.com/scala-infer-models/resnet-18/synset.txt -P $data_path
+  wget https://s3.us-east-2.amazonaws.com/mxnet-scala/scala-example-ci/resnet152/kitten.jpg -P $image_path
+fi


### PR DESCRIPTION
The file was removed in this commit : 
https://github.com/awslabs/deeplearning-benchmark/commit/21b6b8baa662ef3b9bf227f527f750ceef79e8ac

Adding it back again. 