### PR TITLE
Updating reporting for java batch metrics

### DIFF
--- a/reporting/config/benchmarks.yaml
+++ b/reporting/config/benchmarks.yaml
@@ -894,10 +894,10 @@ benchmarks:
     Model: SSD
     Benchmark Desc: Batch size 16
     Instance Type: p3.16xlarge
-    Latency: batch_inference_average
-    P50 Latency: batch_inference_p50
-    P90 Latency: batch_inference_p90
-    P99 Latency: batch_inference_p99
+    Latency: batch_inference_4x_average
+    P50 Latency: batch_inference_4x_p50
+    P90 Latency: batch_inference_4x_p90
+    P99 Latency: batch_inference_4x_p99
 
 # ------------------ Java CPU -------------------------------------------------
   - Metric Prefix: mxnet.java_inference_ssd_cpu
@@ -923,10 +923,10 @@ benchmarks:
     Model: SSD
     Benchmark Desc: Batch size 16
     Instance Type: c5.2xlarge
-    Latency: batch_inference_average
-    P50 Latency: batch_inference_p50
-    P90 Latency: batch_inference_p90
-    P99 Latency: batch_inference_p99
+    Latency: batch_inference_4x_average
+    P50 Latency: batch_inference_4x_p50
+    P90 Latency: batch_inference_4x_p90
+    P99 Latency: batch_inference_4x_p99
 
 # ------------------ ONNX MXNet Import Model - GPU -----------------------------
   - Metric Prefix: mxnet.onnx_mxnet_import_model_inference_test_gpu


### PR DESCRIPTION
When the java benchmark job was moved into this repo the metric names for batches was changed slightly. Updating the reporting tool to reflect this change.

@lanking520 @frankfliu 