### PR TITLE
Adding error logs for failed benchmark runs to s3 log file

### DIFF
--- a/benchmark_driver.py
+++ b/benchmark_driver.py
@@ -4,7 +4,6 @@ import os
 
 from ast import literal_eval
 import logging
-logging.basicConfig(level=logging.INFO)
 
 try:
     import ConfigParser
@@ -22,20 +21,7 @@ CONFIG_DIR = './task_config.cfg'
 
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Run a benchmark task.")
-    parser.add_argument('--framework', type=str, help='Framework name e.g. mxnet')
-    parser.add_argument('--task-name', type=str, help='Task Name e.g. resnet50_cifar10_symbolic.')
-    parser.add_argument('--num-gpus', type=int, help='Numbers of gpus. e.g. --num-gpus 8')
-    parser.add_argument('--epochs', type=int, help='Numbers of epochs for training. e.g. --epochs 20')
-    parser.add_argument('--metrics-suffix', type=str, help='Metrics suffix e.g. --metrics-suffix daily')
-    parser.add_argument('--kvstore', type=str, default='device',help='kvstore to use for trainer/module.')
-    parser.add_argument('--dtype', type=str, default='float32',help='floating point precision to use')
-      
-    
-    
-    args = parser.parse_args()
-
+def run_benchmark(args):
     # modify the template config file and generate the user defined config file.
     cfg_process.generate_cfg(CONFIG_TEMPLATE_DIR, CONFIG_DIR, **vars(args))
     config.read(CONFIG_DIR)
@@ -61,3 +47,25 @@ if __name__ == '__main__':
 
     # clean up
     os.remove(CONFIG_DIR)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Run a benchmark task.")
+    parser.add_argument('--framework', type=str, help='Framework name e.g. mxnet')
+    parser.add_argument('--task-name', type=str, help='Task Name e.g. resnet50_cifar10_symbolic.')
+    parser.add_argument('--num-gpus', type=int, help='Numbers of gpus. e.g. --num-gpus 8')
+    parser.add_argument('--epochs', type=int, help='Numbers of epochs for training. e.g. --epochs 20')
+    parser.add_argument('--metrics-suffix', type=str, help='Metrics suffix e.g. --metrics-suffix daily')
+    parser.add_argument('--kvstore', type=str, default='device',help='kvstore to use for trainer/module.')
+    parser.add_argument('--dtype', type=str, default='float32',help='floating point precision to use')
+
+    args = parser.parse_args()
+
+    log_file_location = args.task_name + ".log"
+    logging.basicConfig(filename=log_file_location,level=logging.DEBUG)
+
+    try:
+        run_benchmark(args)
+    except Exception:
+        logging.exception("Fatal error in run_benchmark")
+        exit()
+

--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -4,7 +4,7 @@ import argparse
 from ast import literal_eval
 
 import logging
-logging.basicConfig(level=logging.INFO)
+
 from utils import metrics_manager
 from utils import data_manager
 try:
@@ -22,19 +22,7 @@ CONFIG_TEMPLATE = './task_config_template.cfg'
 
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Run a benchmark task.")
-    parser.add_argument('--framework', type=str, help='Framework eg. mxnet')
-    parser.add_argument('--metrics-policy', type=str, help='Metrics policy section name e.g. metrics_paramaters_images')
-    parser.add_argument('--task-name', type=str, help='Task Name e.g. resnet50_cifar10_symbolic.')
-    parser.add_argument('--metrics-suffix', type=str, help='Metrics suffix e.g. --metrics-suffix daily')
-    parser.add_argument('--num-gpus', type=int, help='Numbers of gpus. e.g. --num-gpus 8')
-    parser.add_argument('--command-to-execute', type=str, help='The script command that performs benchmarking')
-    parser.add_argument('--data-set', type=str, help='The data set to use for benchmarking, eg. imagenet, imagenet-480px-256px-q95')
-    parser.add_argument('--metrics-template', type=str, help='The template file to use for metrics pattern', default=CONFIG_TEMPLATE)
-    
-    args = parser.parse_args()    
-   
+def run_benchmark(args):
     if 'imagenet' in args.data_set: 
         data_manager.getImagenetData(args.data_set)
 
@@ -60,4 +48,26 @@ if __name__ == '__main__':
         suffix=args.metrics_suffix,
         framework=args.framework
     )
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Run a benchmark task.")
+    parser.add_argument('--framework', type=str, help='Framework eg. mxnet')
+    parser.add_argument('--metrics-policy', type=str, help='Metrics policy section name e.g. metrics_paramaters_images')
+    parser.add_argument('--task-name', type=str, help='Task Name e.g. resnet50_cifar10_symbolic.')
+    parser.add_argument('--metrics-suffix', type=str, help='Metrics suffix e.g. --metrics-suffix daily')
+    parser.add_argument('--num-gpus', type=int, help='Numbers of gpus. e.g. --num-gpus 8')
+    parser.add_argument('--command-to-execute', type=str, help='The script command that performs benchmarking')
+    parser.add_argument('--data-set', type=str, help='The data set to use for benchmarking, eg. imagenet, imagenet-480px-256px-q95')
+    parser.add_argument('--metrics-template', type=str, help='The template file to use for metrics pattern', default=CONFIG_TEMPLATE)
+
+    args = parser.parse_args()
+
+    log_file_location = args.task_name + ".log"
+    logging.basicConfig(filename=log_file_location,level=logging.DEBUG)
+
+    try:
+        run_benchmark(args)
+    except Exception:
+        logging.exception("Fatal error in run_benchmark")
+        exit()
 

--- a/utils/metrics_manager.py
+++ b/utils/metrics_manager.py
@@ -126,11 +126,13 @@ def benchmark(command_to_execute, metric_patterns,
         name of the framework
     :return:
     """
-    log_file_location = task_name + ".log"
-    log_file = open(log_file_location, 'w')
-    logging.info("Executing Command: %s", command_to_execute)
 
     cpu_gpu_memory_usage = {}
+    logging.info("Executing Command: %s", command_to_execute)
+
+    log_file_location = task_name + ".log"
+    log_file = open(log_file_location, 'a')
+
     process = subprocess.Popen(
             command_to_execute,
             shell=True,


### PR DESCRIPTION
## Description
Adding error logs for failed benchmarks to the log file generated in s3. This will help in debugging the benchmark as the error logging in cloudwatch is not very descriptive.

Error logs include the stack trace and are recorded in this format:
```
ERROR:root:Fatal error in run_benchmark
Traceback (most recent call last):
  File "benchmark_runner.py", line 69, in <module>
    run_benchmark(args)
  File "benchmark_runner.py", line 49, in run_benchmark
    framework=args.framework
  File "/home/ubuntu/benchmarkai/utils/metrics_manager.py", line 156, in benchmark
    result.parse_log()
  File "/home/ubuntu/benchmarkai/utils/metrics_manager.py", line 94, in parse_log
    metric=metric
  File "/home/ubuntu/benchmarkai/utils/metrics_manager.py", line 39, in compute
    raise utils.errors.MetricComputeMethodError("This metric compute method is not supported!")
MetricComputeMethodError: This metric compute method is not supported!
```

which is more informative as compared to the cause of error reported by Cloudwatch:
```
Run Benchmark Failed with error - get() encountered an exception while downloading 'benchmarkai/dlbenchmark_result.json'

Underlying exception:
    No such file
```

## Testing
Code has been tested manually using a dummy benchmark on cloudwatch