### PR TITLE
Fix to word_language_model/word_language_model.py for python3 compatibility

### DIFF
--- a/word_language_model/word_language_model.py
+++ b/word_language_model/word_language_model.py
@@ -91,7 +91,7 @@ def eval(data_source, ctx):
     total_L = 0.0
     ntotal = 0
     hidden_states = [
-        model.begin_state(func=mx.nd.zeros, batch_size=args.batch_size/len(ctx), ctx=ctx[i])
+        model.begin_state(func=mx.nd.zeros, batch_size=int(args.batch_size/len(ctx)), ctx=ctx[i])
         for i in range(len(ctx))
     ]
     for i in range(0, data_source.shape[0] - 1, args.bptt):


### PR DESCRIPTION
Without this change the division will return a float number when using python3. `batch_size` will be used to construct a shape which shall only contain integer numbers. In python3 an error will be raised when that shape is used. With this change `batch_size` will still be an integer in python3.