### PR TITLE
fix list map issue

### DIFF
--- a/utils/metrics_manager.py
+++ b/utils/metrics_manager.py
@@ -91,7 +91,7 @@ class BenchmarkResultManager(object):
             metric = map(self.__get_float_number, metric)
             metric_result = BenchmarkMetricComputeMethod.compute(
                 metric_compute_method=self.metric_compute_methods[i],
-                metric=[metric]
+                metric=list(metric)
             )
             self.metric_map[name] = metric_result
         self.metric_map['uptime_in_seconds'] = self.uptime()


### PR DESCRIPTION
*Issue #, if available:*

Converting a map to list was incorrect

Current implementation

[metric] leads to error

```
ERROR:root:Fatal error in run_benchmark
Traceback (most recent call last):
  File "benchmark_driver.py", line 67, in <module>
    run_benchmark(args)
  File "benchmark_driver.py", line 45, in run_benchmark
    framework=args.framework
  File "/home/ubuntu/dl_model_benchmark/deeplearning-benchmark/utils/metrics_manager.py", line 156, in benchmark
    result.parse_log()
  File "/home/ubuntu/dl_model_benchmark/deeplearning-benchmark/utils/metrics_manager.py", line 94, in parse_log
    metric=[metric]
  File "/home/ubuntu/dl_model_benchmark/deeplearning-benchmark/utils/metrics_manager.py", line 23, in compute
    return 1.0 * sum(metric) / len(metric)
TypeError: unsupported operand type(s) for +: 'int' and 'map'

```

Solution
list(metric)

### Example
```
>>> import numpy as np
>>> x = np.arange(20)
>>> a=map(lambda x: x + np.random.randn(1), x)
>>> a
<map object at 0x7fc6e02b9e48>
```
#### Calling `list()`
```
>>> list(a)
[array([0.47293413]), array([0.73330922]), array([2.73388234]), array([1.87557948]), array([4.70554551]), array([6.4415065]), array([5.32354042]), array([7.07631866]), array([7.55568775]), array([9.14767512]), array([10.58723751]), array([9.21136723]), array([10.51711882]), array([13.16280252]), array([15.0088883]), array([14.02306192]), array([16.03734395]), array([16.53270972]), array([17.76548674]), array([19.16387645])]
```
#### Calling `[a]`
```
>>> [a]
[<map object at 0x7fc6e02b9e48>]
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
