### PR TITLE
Use native python library to unzip instead of system package

### DIFF
--- a/image_classification/get_data.py
+++ b/image_classification/get_data.py
@@ -40,7 +40,6 @@ def GetMNIST_ubyte():
         os.chdir("./data")
         with ZipFile('mnist.zip', 'r') as zipObj:
             zipObj.extractall()
-        os.system("unzip -u mnist.zip")
         os.chdir("..")
 
 # download cifar

--- a/image_classification/get_data.py
+++ b/image_classification/get_data.py
@@ -19,6 +19,7 @@
 import os, gzip
 import pickle as pickle
 import sys
+from zipfile import ZipFile
 
 # download mnist.pkl.gz
 def GetMNIST_pkl():
@@ -37,6 +38,8 @@ def GetMNIST_ubyte():
        (not os.path.exists('data/t10k-labels-idx1-ubyte')):
         os.system("wget -q http://data.mxnet.io/mxnet/data/mnist.zip -P data/")
         os.chdir("./data")
+        with ZipFile('mnist.zip', 'r') as zipObj:
+            zipObj.extractall()
         os.system("unzip -u mnist.zip")
         os.chdir("..")
 
@@ -50,5 +53,6 @@ def GetCifar10():
        (not os.path.exists('data/cifar/test.lst')):
         os.system("wget -q http://data.mxnet.io/mxnet/data/cifar10.zip -P data/")
         os.chdir("./data")
-        os.system("unzip -u cifar10.zip")
+        with ZipFile('cifar10.zip', 'r') as zipObj:
+            zipObj.extractall()
         os.chdir("..")


### PR DESCRIPTION
*Issue:* unzip package needs to be installed on the instance/container image where the script needs to run 

*Description of changes:* Using Python library to remove dependency from system package

*Testing:*
```
python deeplearning-benchmark/image_classification/image_classification.py --model resnet18_v2 --dataset mnist --mode symbolic --gpus 0 --epochs 25 --log-interval 50 --kvstore local --dtype='float32' --batch-size=64

python deeplearning-benchmark/image_classification/image_classification.py --model resnet18_v2 --dataset mnist --mode symbolic --gpus 0 --epochs 25 --log-interval 50 --kvstore local --dtype='float32' --batch-size=64
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
